### PR TITLE
Fix: cache le logo dans l'export si fontSize = 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# vscode
 .vscode/launch.json

--- a/components/youtube-video-card.tsx
+++ b/components/youtube-video-card.tsx
@@ -115,6 +115,8 @@ export function YouTubeVideoCard({
               borderRadius: "100%",
               width: `${scale.fontSize(2.6)}px`,
               height: `${scale.fontSize(2.6)}px`,
+              // Nécessaire pour l'export. Satori ne gère pas width: 0
+              display: scale.fontSize(2.6) ? 'none' : 'block',
             }}
           />
         )}


### PR DESCRIPTION
Satori ne gère pas width: '0px' pour les images.
Du coup, si on mettait la fontSize à 0, le logo apparaissait en gros dans l'export.
Personne ne devait faire des exports sans le texte mais c'est quand même un bug =p